### PR TITLE
Add OpenIddict classes to docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "openiddict-core"]
+	path = openiddict-core
+	url = https://github.com/openiddict/openiddict-core
+	branch = dev

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
 
 install:
   - ps: |
-        git submodule update --init --recursive
+        git submodule update -q --init --recursive
         
 build_script:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ environment:
   access_token:
     secure: YusB3g3MzZkV+HZr30L99yz+LgFJkN9cJrxHhvZpjThKGFJMZHO2TpXxWsdgi+7L
 
+install:
+  - ps: |
+        git submodule update --init --recursive
+        
 build_script:
   - ps: |
         nuget install docfx.console -Version 2.24.0

--- a/docfx.json
+++ b/docfx.json
@@ -3,7 +3,7 @@
     {
       "src": [
         {
-          "files": [ "**/*.cs" ],
+          "files": [ "src/**/*.cs" ],
           "exclude": [ "**/bin/**", "**/obj/**" ],
           "cwd": "../openiddict-core"
         }

--- a/docfx.json
+++ b/docfx.json
@@ -1,6 +1,23 @@
 {
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.cs" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "cwd": "../openiddict-core"
+        }
+      ],
+      "dest": "obj/api"
+    }
+  ],
   "build": {
     "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
       {
         "files": [
           "**/*.md",
@@ -10,7 +27,8 @@
           "appveyor.yml",
           "README.md",
           "obj/**",
-          "_site/**"
+          "_site/**",
+          "openiddict-core/**/*.yml"
         ]
       }
     ],

--- a/toc.yml
+++ b/toc.yml
@@ -6,3 +6,6 @@
 
 - name: Features
   href: features/index.md
+
+- name: API Documentation
+  href: obj/api/


### PR DESCRIPTION
This adds documentation for all the OpenIddict Core classes to the documentation website.

@PinpointTownes  I am not 100% sure about the `install` step I added to the `appveyor.yml` file as I cannot test this on my side. I based it [on this section in the Appveyor docs](https://www.appveyor.com/docs/how-to/private-git-sub-modules/#the-problem-with-private-sub-modules)

Once the sub-module is in place, the actual docfx generation seems to work fine on my side ;)

Closes #11