### PR TITLE
Do not run deploy to GitHub Pages for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ jobs:
         args: docfx.json
 
     - name: Deploy to GitHub Pages
+      if: ${{ github.repository_owner == 'openiddict' && (github.ref == 'refs/heads/dev' || startsWith(github.ref, 'refs/heads/rel/') || startsWith(github.ref, 'refs/tags/')) }}
       uses: JamesIves/github-pages-deploy-action@releases/v3
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current workflow always tries to deploy to GitHub Pages when building, even on PRs, which promptly fails. This PR makes it so that the deploy step will not run for PRs (and consequently fixes the build failure of #26).