### PR TITLE
Update integration documentation to include pixel-identity project

### DIFF
--- a/integrations/index.md
+++ b/integrations/index.md
@@ -4,3 +4,4 @@ OpenIddict offers native integrations with popular Object–relational Mapping t
 
 Documentation for integrations maintained by the OpenIddict community can be found in their respective repositories:
 - **[P41.OpenIddict.CouchDB](https://github.com/panoukos41/couchdb-openiddict)** by [Panos Athanasiou](https://github.com/panoukos41): CouchDB stores for OpenIddict.
+- **[pixel-identity](https://github.com/Nfactor26/pixel-identity)** by [Nishant Singh](https://github.com/Nfactor26): Ready to host OpenID Connect service using OpenIddict and ASP.NET Identity with a Blazor-based UI for managing users, roles, applications and scopes with support for multiple databases.


### PR DESCRIPTION
**Description**
Added [pixel-identity](https://github.com/Nfactor26/pixel-identity) project to integration documentation page of OpenIddict.