### PR TITLE
Document indexing token.AuthorizationId property

### DIFF
--- a/integrations/mongodb.md
+++ b/integrations/mongodb.md
@@ -123,6 +123,14 @@ initialize the database and create the indexes used by the OpenIddict entities:
             }),
 
         new CreateIndexModel<OpenIddictMongoDbToken>(
+            Builders<OpenIddictMongoDbToken>.IndexKeys.Ascending(token => token.AuthorizationId),
+            new CreateIndexOptions<OpenIddictMongoDbToken>()
+            {
+                PartialFilterExpression =
+                    Builders<OpenIddictMongoDbToken>.Filter.Exists(token => token.AuthorizationId),
+            }),
+
+        new CreateIndexModel<OpenIddictMongoDbToken>(
             Builders<OpenIddictMongoDbToken>.IndexKeys
                 .Ascending(token => token.ApplicationId)
                 .Ascending(token => token.Status)


### PR DESCRIPTION
I suggest creating an index also on `token.AuthorizationId`, which is occasionally used in [token exchange](https://github.com/openiddict/openiddict-core/blob/2e301ce8f29767a1765932ef9d0af755ccaf7e97/src/OpenIddict.Server/OpenIddictServerHandlers.Protection.cs#L953) as well as [during authorization pruning](https://github.com/openiddict/openiddict-core/blob/2e301ce8f29767a1765932ef9d0af755ccaf7e97/src/OpenIddict.MongoDb/Stores/OpenIddictMongoDbTokenStore.cs#LL569C41-L569C41). Those two use cases can generate quite a lot database overhead when token database is big enough (in my case, ~25 million records)