### PR TITLE
Add build & run instructions for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,30 @@ This repository provides the documentation for the [OpenIddict](https://github.c
 Security issues and bugs should be reported privately by emailing security@openiddict.com.
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
 
+## Development
+
+In order to build and run the documentation locally, follow these steps:
+
+1. Clone the Git repository including submodules:
+
+   ```bash
+   git clone --recurse-submodules https://github.com/openiddict/openiddict-documentation.git
+   ```
+
+2. Install [docfx](https://dotnet.github.io/docfx/) as a global tool:
+
+   ```bash
+   dotnet tool update -g docfx
+   ```
+
+3. Build the documentation and serve it locally:
+
+   ```bash
+   docfx docfx.json --serve
+   ```
+
+   The documentation will be available on http://localhost:8080.
+
 ## Support
 
 If you need support, please make sure you [sponsor the project](https://github.com/sponsors/kevinchalet) before creating a GitHub ticket.


### PR DESCRIPTION
This adds a **Development** section to the main README, that explains how to build & run the documentation locally for development.