### PR TITLE
Update 5->6 Migration Guide to note changes in how null redirect URIs are now handled

### DIFF
--- a/guides/migration/50-to-60.md
+++ b/guides/migration/50-to-60.md
@@ -212,46 +212,22 @@ if (result is { Identity.IsAuthenticated: true })
 }
 ```
 
-## Changes to Redirect URI handling
-The [RedirectUri handling](https://github.com/openiddict/openiddict-core/compare/5.8.0...6.1.1#diff-2a87820215e5f2a8d9155ac446b58b4925e941461a9d42537d6bcbb59b4c9dbdR584) has changed in OpenIddict 6, and will no longer pass a "null" or empty RedirectUri from a Challenge initiated in an ASPNET Controller, to the remote IdP, and will instead default to the path where that challenge initiated. This can create an infinite redirect loop if you are using a controller action to initiate the remote login request.
-If your application issues a 3rd party authentication Challenge, such as this:
+## If necessary, set a specific target link URI to avoid login loops
+
+In OpenIddict 6.0, the client stack now automatically uses the current URI as the default target link URI when the `AuthenticationProperties.RedirectUri`
+is not explicitly set when the challenge is triggered: if the current URI points to a controller action or minimal action that directly triggers a challenge,
+this may create an infinite redirect loop. To avoid that, make sure you're always setting `AuthenticationProperties.RedirectUri` to a non-null value:
 
 ```chsarp
-[Route(nameof(LoginEntra))]
-[HttpGet]
-[AllowAnonymous]
-public IActionResult LoginEntra(string returnUrl = null)
-{
-	ViewData["ReturnUrl"] = returnUrl;
-	return Challenge(
-		authenticationSchemes: "MicrosoftEntra",
-		properties: new AuthenticationProperties
-		{
-			Items = { { "ReturnUrl", returnUrl } } /* Note, in this example, the server is acting as an SSO provider, so returnUrl is being used to pass the user back to the initiating application. Data in Items is treated as a pass through, and not a RedirectUri or requisite part of the request flow */
-		}
-	);
-	//OpenIddict will use the Challenge result to talk to the configured provider automatically.
-}
-```
-
-You will need to specify the RedirectUri to some other path in your server application:
-
-```chsarp
-[Route(nameof(LoginEntra))]
-[HttpGet]
-[AllowAnonymous]
-public IActionResult LoginEntra(string returnUrl = null)
-{
-	return Challenge(
-		authenticationSchemes: "MicrosoftEntra",
-		properties: new AuthenticationProperties
-		{
-			RedirectUri = "/",
-			Items = { { "ReturnUrl", returnUrl } } /* Note, in this example, the server is acting as an SSO provider, so returnUrl is being used to pass the user back to the initiating application. Data in Items is treated as a pass through, and not a RedirectUri or requisite part of the request flow */
-		}
-	);
-	//OpenIddict will use the Challenge result to talk to the configured provider automatically.
-}
+[AllowAnonymous, HttpGet, Route("~/login-with-entra")]
+public IActionResult LoginWithEntra(string? returnUrl = null) => Challenge(
+    authenticationSchemes: OpenIddictClientWebIntegrationConstants.Providers.Microsoft,
+    properties: new AuthenticationProperties
+    {
+        // Only allow local return URLs to prevent open redirect attacks and redirect the
+        // user agent to the root page if no return URL was attached to the query string.
+        RedirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/"
+    });
 ```
 
 ## Update your custom stores (if applicable)

--- a/guides/migration/50-to-60.md
+++ b/guides/migration/50-to-60.md
@@ -212,6 +212,48 @@ if (result is { Identity.IsAuthenticated: true })
 }
 ```
 
+## Changes to Redirect URI handling
+The [RedirectUri handling](https://github.com/openiddict/openiddict-core/compare/5.8.0...6.1.1#diff-2a87820215e5f2a8d9155ac446b58b4925e941461a9d42537d6bcbb59b4c9dbdR584) has changed in OpenIddict 6, and will no longer pass a "null" or empty RedirectUri from a Challenge initiated in an ASPNET Controller, to the remote IdP, and will instead default to the path where that challenge initiated. This can create an infinite redirect loop if you are using a controller action to initiate the remote login request.
+If your application issues a 3rd party authentication Challenge, such as this:
+
+```chsarp
+[Route(nameof(LoginEntra))]
+[HttpGet]
+[AllowAnonymous]
+public IActionResult LoginEntra(string returnUrl = null)
+{
+	ViewData["ReturnUrl"] = returnUrl;
+	return Challenge(
+		authenticationSchemes: "MicrosoftEntra",
+		properties: new AuthenticationProperties
+		{
+			Items = { { "ReturnUrl", returnUrl } } /* Note, in this example, the server is acting as an SSO provider, so returnUrl is being used to pass the user back to the initiating application. Data in Items is treated as a pass through, and not a RedirectUri or requisite part of the request flow */
+		}
+	);
+	//OpenIddict will use the Challenge result to talk to the configured provider automatically.
+}
+```
+
+You will need to specify the RedirectUri to some other path in your server application:
+
+```chsarp
+[Route(nameof(LoginEntra))]
+[HttpGet]
+[AllowAnonymous]
+public IActionResult LoginEntra(string returnUrl = null)
+{
+	return Challenge(
+		authenticationSchemes: "MicrosoftEntra",
+		properties: new AuthenticationProperties
+		{
+			RedirectUri = "/",
+			Items = { { "ReturnUrl", returnUrl } } /* Note, in this example, the server is acting as an SSO provider, so returnUrl is being used to pass the user back to the initiating application. Data in Items is treated as a pass through, and not a RedirectUri or requisite part of the request flow */
+		}
+	);
+	//OpenIddict will use the Challenge result to talk to the configured provider automatically.
+}
+```
+
 ## Update your custom stores (if applicable)
 
 ### New APIs


### PR DESCRIPTION
Adds a note about changes to RedirectUri handling when performing Challenges, and populating those URLs within an AuthenticateResult, during IdP callback processing.